### PR TITLE
Draft to-asg command

### DIFF
--- a/pasc.py
+++ b/pasc.py
@@ -250,7 +250,7 @@ FUNCTOR_TO_CLASS = {
 }
 
 
-def main():
+def parse_from_args():
     if sys.argv[1] == "-":
         stdin = sys.stdin.read()
         with tempfile.NamedTemporaryFile(delete=False) as stdin_file:
@@ -261,6 +261,11 @@ def main():
             os.remove(stdin_file.name)
     else:
         docs = parse_asciidoc(sys.argv[1])
+    return docs
+
+
+def main():
+    docs = parse_from_args()
     if len(docs) > 1:
         print("Ambiguous parse")
         for i, doc in enumerate(docs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ swiplserver = "^1.0.2"
 
 [tool.poetry.scripts]
 pasc = 'pasc:main'
+to-asg = 'to_asg:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/to_asg.py
+++ b/to_asg.py
@@ -1,0 +1,50 @@
+import json
+import os
+import re
+import sys
+import tempfile
+
+import pasc
+
+
+def transform_document(d):
+    return {
+        "body": list(filter(None, map(transform, d.blocks))),
+    }
+
+
+def transform_paragraph(p):
+    return {
+        "type": "Paragraph",
+        "lines": convert_texts(p.content),
+    }
+
+
+def convert_texts(ts):
+    return list(map(convert_text, ts))
+
+
+def convert_text(t):
+    return re.sub(r"\s+", " ", t.text).strip()
+
+
+TRANSFORMERS = {
+    pasc.Document : transform_document,
+    pasc.Paragraph: transform_paragraph,
+    pasc.BlockSeparator: lambda _: None,
+}
+
+
+def transform(e):
+    return TRANSFORMERS[type(e)](e)
+
+
+def main():
+    docs = pasc.parse_from_args()
+    assert len(docs) == 1, "ambiguous parse"
+    doc = docs[0]
+    print(json.dumps(transform(doc)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
```
$ cat pr-docker
#!/bin/sh

docker run -i --rm quay.io/alexpdp7/prolog-asciidoc:asg_tck to-asg -
$ chmod +x pr-docker
$ ASCIIDOC_TCK_ADAPTER=./pr-docker ./node_modules/asciidoc-tck/bin/asciidoc-tck.js


  paragraph
    1) attribute-sub
    ✔ simple (871ms)


  1 passing (2s)
  1 failing

  1) paragraph
...
```